### PR TITLE
Inputs

### DIFF
--- a/JS/deGE.js
+++ b/JS/deGE.js
@@ -73,16 +73,21 @@ function changeLanguageDE(){
 import {errorsRegister} from "./script.js";
 import {errorsMsg} from "./languages.js";
 
+import { errorPassword } from "./languages.js";
+import{ changeErrorLang } from "./script.js";
+
 // Navigator user language
 var userLang = navigator.language || navigator.userLanguage; 
 if(userLang === "de") {
     changeLanguageDE(),
     errorsRegister.changeL(errorsMsg.de);
     errorsRegister.changeLogin(errorsMsg.de.i1);
+    changeErrorLang("DE", errorPassword.de );
 }
 
 de.addEventListener("click", () => {
     changeLanguageDE(),
     errorsRegister.changeL(errorsMsg.de);
     errorsRegister.changeLogin(errorsMsg.de.i1);
+    changeErrorLang("DE", errorPassword.de );
 });

--- a/JS/languages.js
+++ b/JS/languages.js
@@ -69,6 +69,12 @@ const errorsMsg = {
     }
 }
 
-export {ptBR, deGE, errorsMsg};
+const errorPassword = {
+    en: "The password must contain at least 8 characters and an uppercase letter, a lowercase letter and an symbol $-!",
+    pt: "A senha deve conter pelo menos 8 caracteres e uma letra maiúscula, uma minúscula e um símbolo #?@",
+    de: "Geben Sie ein Passwort mit 8 Zeichen ein, das 1 Großbuchstaben, 1 Kleinbuchstaben und 1 Symbol enthält ^@&"
+}
+
+export {ptBR, deGE, errorsMsg, errorPassword};
 
 

--- a/JS/ptBR.js
+++ b/JS/ptBR.js
@@ -67,6 +67,7 @@ function changeLanguageBR(){
 // and importing portuguese errors messages from languages.js
 import {errorsRegister} from "./script.js";
 import {errorsMsg} from "./languages.js";
+
 import { errorPassword } from "./languages.js";
 import{ changeErrorLang } from "./script.js";
 
@@ -77,6 +78,7 @@ if(userLang === "pt" || userLang === "pt-BR") {
     changeLanguageBR(),
     errorsRegister.changeL(errorsMsg.pt);
     errorsRegister.changeLogin(errorsMsg.pt.i1);
+    changeErrorLang("PT", errorPassword.pt );
 }
 
 pt.addEventListener("click", () => {

--- a/JS/ptBR.js
+++ b/JS/ptBR.js
@@ -67,6 +67,9 @@ function changeLanguageBR(){
 // and importing portuguese errors messages from languages.js
 import {errorsRegister} from "./script.js";
 import {errorsMsg} from "./languages.js";
+import { errorPassword } from "./languages.js";
+import{ changeErrorLang } from "./script.js";
+
 
 // Navigator user language
 var userLang = navigator.language || navigator.userLanguage;
@@ -80,4 +83,5 @@ pt.addEventListener("click", () => {
     changeLanguageBR(),
     errorsRegister.changeL(errorsMsg.pt),
     errorsRegister.changeLogin(errorsMsg.pt.i1)
+    changeErrorLang("PT", errorPassword.pt );
 });

--- a/JS/script.js
+++ b/JS/script.js
@@ -140,7 +140,8 @@ class CheckInp{
 
             // Check if both inputs are true, if not, it wil return an error.
             this.inputs.forEach((i) => {
-                !i.checkValidity() ? i.nextElementSibling.classList.add("error-actived") : i.nextElementSibling.classList.remove("error-actived");
+                !i.checkValidity() ? i.nextElementSibling.classList.add("error-actived")
+                    : i.nextElementSibling.classList.remove("error-actived");
             })
 
         }, 1000)
@@ -173,7 +174,6 @@ function registerLanguage(...p){
     Rlabels.concat(tags).forEach((t) => t.innerText = arrUK.shift());
     allInputs[4].placeholder = "(XXX) XXXX XXXX";
 }
-
 
 
 // Errors in REGISTER FORM.
@@ -210,54 +210,54 @@ class Errors{
     
 }
 
+export const errorsRegister = new Errors();
+
+// Language page will be English if the browser's language is English.
+var userLang = navigator.language || navigator.userLanguage;
 if(userLang === "en") {
     errorsRegister.languagesTest(errorsMsg.en),
     errorsRegister.changeLogin(errorsMsg.en.i1);
 }
 
-export const errorsRegister = new Errors();
+// Checking password input from Register Form.
+const initials = document.querySelector("[data-initials]");
 
-
-// This event change the login/register page in English
-// and also active the class which check if the inputs are true or not.
-en.addEventListener("click", () => {
-    engLogin("[data-initials]", ".f-password", ".btn",".p-register","[data-span='register']"),
-    registerLanguage("[data-h1]", "[data-btn='2']", ".p-signIN", "[data-span='login']"),
-    errorsRegister.changeL(errorsMsg.en),
-    errorsRegister.changeLogin(errorsMsg.en.i1)
-});
-
-
-
-
-
-// Checking password input
-const initals = document.querySelector("[data-initials]");
-
-// Não deve conter espaços
+// Password Input
 const pswrd = allInputs[5]
 
-// (WARNING) Put this on the top of the script
-var userLang = navigator.language || navigator.userLanguage;
+import {errorPassword} from "./languages.js";
 
-function checkPswrd(){
-    // Should contain at least number, one lower case, one upper case.
-    let errorMSG = "";
-    if(initals.classList.contains("PT")) errorMSG = "A senha deve conter pelo menos 8 caracteres e uma letra maiúscula, uma minúscula e um símbolo #?@"
-    if(initals.classList.contains("EN")) errorMSG = "The password must contain at least 8 characters and an uppercase letter, a lowercase letter and an symbol $-!"
-    if(initals.classList.contains("DE")) errorMSG = "Geben Sie ein Passwort mit 8 Zeichen ein, das 1 Großbuchstaben, 1 Kleinbuchstaben und 1 Symbol enthält ^@&";
+// Change the error language.
+let errorMsg = "";
 
+// Ativar ao click pela linguagem.
+export function changeErrorLang(language, text){ if(initials.classList.contains(language)) errorMsg = text; }
 
+// Ativar ao change do pswrd.
+function checkPassword(){
     if(pswrd.value.search(/(?=.*\d)(?=.*[a-z]{1})(?=.*[A-Z]{1})(?=.*[-!$%^&@#?]{1})([\w{7}])/) === -1){
         pswrd.nextElementSibling.classList.add("error-actived")
-        pswrd.nextElementSibling.innerText = errorMSG;
+        pswrd.nextElementSibling.innerText = errorMsg;
     } else {
         return true;
     }
 }
 
-pswrd.addEventListener("change", () => checkPswrd());
+pswrd.addEventListener("change", () => checkPassword());
 
+// This event change the login/register page in English
+// and also active the Class that check if the inputs are true or not.
+en.addEventListener("click", () => {
+    engLogin("[data-initials]", ".f-password", ".btn",".p-register","[data-span='register']"),
+    registerLanguage("[data-h1]", "[data-btn='2']", ".p-signIN", "[data-span='login']"),
+    errorsRegister.changeL(errorsMsg.en),
+    errorsRegister.changeLogin(errorsMsg.en.i1)
+    changeErrorLang("EN", errorPassword.en);
+});
+
+// function english(){
+
+// }
 
 // Confirm Password
 const confirmP = allInputs[6];

--- a/JS/script.js
+++ b/JS/script.js
@@ -217,6 +217,7 @@ var userLang = navigator.language || navigator.userLanguage;
 if(userLang === "en") {
     errorsRegister.languagesTest(errorsMsg.en),
     errorsRegister.changeLogin(errorsMsg.en.i1);
+    changeErrorLang("EN", errorPassword.en);
 }
 
 // Checking password input from Register Form.


### PR DESCRIPTION
Rebuilded both methods: Check password input (that show us an error message in the language that we want), and Change the error language in password input.

As I did before in other language's functions, I choose an option for the user that it consists if he want to change the language page through our Language Menu or If he doesn't want it, the language in the page will be the same as in his browser.